### PR TITLE
[improvement] Yield event after successful tracking to allow farther processing

### DIFF
--- a/lib/ahoy/database_store.rb
+++ b/lib/ahoy/database_store.rb
@@ -19,6 +19,7 @@ module Ahoy
         event.time = visit.started_at if event.time < visit.started_at
         begin
           event.save!
+          event
         rescue => e
           raise e unless unique_exception?(e)
         end

--- a/lib/ahoy/tracker.rb
+++ b/lib/ahoy/tracker.rb
@@ -16,7 +16,7 @@ module Ahoy
     end
 
     # can't use keyword arguments here
-    def track(name, properties = {}, options = {})
+    def track(name, properties = {}, options = {}, &block)
       if exclude?
         debug "Event excluded"
       elsif missing_params?
@@ -31,7 +31,8 @@ module Ahoy
           event_id: options[:id] || generate_id
         }.select { |_, v| v }
 
-        @store.track_event(data)
+        event = @store.track_event(data)
+        block.call(event) if block_given?
       end
       true
     rescue => e


### PR DESCRIPTION
This is needed for example to get an id of the event and to associate it with some other entities.