### PR TITLE
[DEV-6493] Mark tracker if visit token is coming from params

### DIFF
--- a/lib/ahoy/tracker.rb
+++ b/lib/ahoy/tracker.rb
@@ -13,6 +13,7 @@ module Ahoy
       @visit_token = options[:visit_token]
       @user = options[:user]
       @options = options
+      @visit_from_param = nil
     end
 
     # can't use keyword arguments here
@@ -154,6 +155,10 @@ module Ahoy
       delete_cookie("ahoy_track")
     end
 
+    def visit_from_param?
+      @visit_from_param
+    end
+
     protected
 
     def api?
@@ -238,7 +243,11 @@ module Ahoy
       @existing_visit_token ||= begin
         token = visit_header
         token ||= visit_cookie if Ahoy.cookies && !(api? && Ahoy.protect_from_forgery && !Ahoy.force_httponly_cookies)
-        token ||= visit_param if api? || allow_visit_param?
+
+        if !token && (api? || allow_visit_param?)
+          (token = visit_param) && @visit_from_param = true
+        end
+
         token
       end
     end

--- a/lib/ahoy/tracker.rb
+++ b/lib/ahoy/tracker.rb
@@ -156,7 +156,7 @@ module Ahoy
     end
 
     def visit_from_param?
-      @visit_from_param
+      visit_token && @visit_from_param
     end
 
     protected

--- a/lib/ahoy/tracker.rb
+++ b/lib/ahoy/tracker.rb
@@ -244,9 +244,10 @@ module Ahoy
         token = visit_header
         token ||= visit_cookie if Ahoy.cookies && !(api? && Ahoy.protect_from_forgery && !Ahoy.force_httponly_cookies)
 
-        if !token && (api? || allow_visit_param?)
-          (token = visit_param) && @visit_from_param = true
-        end
+        token ||= begin
+            @visit_from_param = true if visit_param
+            visit_param
+          end if api? || allow_visit_param?
 
         token
       end


### PR DESCRIPTION
Adds an API to the tracker for checking whether the visit token came from params. Since cookies take precedence over params it automatically means that a new cookie will be set with the token from params and also means it's a new session start because cookies were empty.

Needed for:
https://github.com/KMDPartners/Mono/pull/4439